### PR TITLE
Adding focus listeners to a set

### DIFF
--- a/src/main/java/org/jitsi/jicofo/FocusManager.java
+++ b/src/main/java/org/jitsi/jicofo/FocusManager.java
@@ -128,7 +128,7 @@ public class FocusManager
      * FIXME: remove eventually if not used anymore
      * The list of {@link FocusAllocationListener}.
      */
-    private FocusAllocationListener focusAllocListener;
+    private List<FocusAllocationListener> focusAllocListeners = new ArrayList<FocusAllocationListener>();
 
     /**
      * XMPP protocol provider handler used by the focus.
@@ -219,7 +219,6 @@ public class FocusManager
             componentsDiscovery.stop();
             componentsDiscovery = null;
         }
-
         meetExtensionsHandler.dispose();
 
         protocolProviderHandler.stop();
@@ -363,9 +362,9 @@ public class FocusManager
             "Disposed conference for room: " + roomName
             + " conference count: " + conferences.size());
 
-        if (focusAllocListener != null)
+        for (FocusAllocationListener listener : this.focusAllocListeners)
         {
-            focusAllocListener.onFocusDestroyed(roomName);
+            listener.onFocusDestroyed(roomName);
         }
 
         // Send focus destroyed event
@@ -453,9 +452,9 @@ public class FocusManager
      * allocation/disposal.
      * @param l the listener instance to be registered.
      */
-    public void setFocusAllocationListener(FocusAllocationListener l)
+    public synchronized void setFocusAllocationListener(FocusAllocationListener l)
     {
-        this.focusAllocListener = l;
+        this.focusAllocListeners.add(l);
     }
 
     /**


### PR DESCRIPTION
Protecting set on listener set

Removing unneccesary comment

Changing set to list as that is what is specified in the
code...

Some test code to make sure the FocusListeners are getting
destroyed as expected...

Removing debug code

Some debugging code for conference timeouts...

Get room is not a method for conference :/

Debugging conference map

Changing listener to listeners

Removing unneccessary logging

Reverting .gitignore
